### PR TITLE
Equatorial B1950.0 coordinates

### DIFF
--- a/RealSolarSystem.cfg
+++ b/RealSolarSystem.cfg
@@ -151,14 +151,15 @@ REALSOLARSYSTEM
 		Radius = 6371000
     // Stellar day.
 		rotationPeriod = 86164.098903691
-    // Inital rotation computed from http://www.ephemeris.com/goto.php.
+    // Inital rotation computed from http://ephemeris.com/ephemeris.php.
     // at a longitude of 0.
-    // The date was set to 1950.01.01 00:00:26 UTC, in order to match the 
+    // The date was set to 1950-01-01 00:00:26 UTC, in order to match the 
     // JD (2433282.500301) as close as possible to the beginning of the game,
     // 1950-01-01 00:00:00 Temps Atomique International == JD2433282.5003725.
-    // The result from the ephemeride was 06:40:44, converted to degrees.
+    // The result from the ephemeride was 06:40:44, converted to 100.1833 deg.
+    // We add 90 degrees because KSP is being silly.
     // NOTE THAT INITAL ROTATION IS NOT AFFECTED BY THE EPOCH SETTING.
-    initialRotation = 100.1833
+    initialRotation = 190.1833
 		tidallyLocked = false
 		axialTilt = 23.44
 		atmosphereScaleHeight = 8.5
@@ -534,7 +535,7 @@ REALSOLARSYSTEM
 			eccentricity        = 0.09326110278323557
 			inclination         = 24.69272426910055
 			meanAnomalyAtEpochD = 169.3913127942378
-			LAN                 = 335.1911063089117
+			LAN                 = 3.351911063089117
 			argumentOfPeriapsis = 332.1022655295414
 		}
 		CelestialBodyScienceParams


### PR DESCRIPTION
The name of my branch is misleading :-p.
EDIT: apparently you use tabs for indentation, while I use 2 spaces, so the indentation is inconsistent. I'll let you fix that.
To quote my comments:

``` c#
  // Form: Epoch is the time in seconds until the epoch of orbital elements.
  // We use B1950.0 == 1949-12-31 22:09:18.216 Temps Atomique International.
  // The game starts at 1950-01-01 00:00:00.0000 Temps Atomique International.
  // In other words, the year 1950 begins in Greenwich roughly when the game
  // starts (We do *not* use UTC because leap seconds are discontinuous, and UTC
  // is not defined in 1950; UT1 is a right mess).
  // The time to epoch was computed as -(24*3600 - 22*3600 - 9*60 - 18.216).

  // The orbital elements are computed using the Jet Propulsion Laboratory
  // HORIZONS system (http://ssd.jpl.nasa.gov/horizons.cgi) using the following
  // settings in order to get correct axial tilt for Earth at epoch:
  //   Start time      : A.D. 1949-Dec-31 22:09:50.4000 CT [JD2433282.4235]
  //   Reference frame : FK4/B1950.0  
  //   Output type     : GEOMETRIC osculating elements
  //   Coordinate systm: Earth Mean Equator and Equinox of Reference Epoch
  //   We use the primary's centre as our centre, this results in accurate
  // positions at epoch. To quote HORIZONS,
  //   Reference epoch: B1950.0 
  //   xy-plane: plane of the Earth's mean equator at the reference epoch
  //   x-axis  : out along ascending node of instantaneous plane of the Earth's
  //            orbit and the Earth's mean equator at the reference epoch
  //   z-axis  : along the Earth mean north pole at the reference epoch
  // We do not set the periods because nothing good can come out of
  // inconsistent orbital elements.

    // Inital rotation computed from http://ephemeris.com/ephemeris.php.
    // at a longitude of 0.
    // The date was set to 1950-01-01 00:00:26 UTC, in order to match the 
    // JD (2433282.500301) as close as possible to the beginning of the game,
    // 1950-01-01 00:00:00 Temps Atomique International == JD2433282.5003725.
    // The result from the ephemeride was 06:40:44, converted to 100.1833 deg.
    // We add 90 degrees because KSP is being silly.
    // NOTE THAT INITAL ROTATION IS NOT AFFECTED BY THE EPOCH SETTING.
```
