### PR TITLE
Fixed bad maxAtmosphereAltitude fields.

### DIFF
--- a/RealSolarSystem/RealSolarSystem.cfg
+++ b/RealSolarSystem/RealSolarSystem.cfg
@@ -141,12 +141,16 @@ REALSOLARSYSTEM
 		tidallyLocked = false
 		axialTilt = 177.36
 		atmosphereScaleHeight = 15.9
-		maxAtmosphereAltitude = 350000
+
+		// IF YOU MODIFY pressureCurve then you MUST ensure that maxAtmosphereAltitude is set to the highest altitude present in pressureCurve (in meters)
+		maxAtmosphereAltitude = 140000
+
 		atmosphereMultiplier = 55
 		atmosphere = true
 		//GeeASL = 0.905
 		Mass = 4.8676E+24
 		useLegacyAtmosphere = false
+		// IF YOU MODIFY pressureCurve then you MUST ensure that maxAtmosphereAltitude is set to the highest altitude present in pressureCurve (in meters)
 		pressureCurve
 		{
 			key = 	0	89.9811265137	0	-5.4657122757
@@ -382,7 +386,10 @@ REALSOLARSYSTEM
 		tidallyLocked = false
 		axialTilt = 23.44
 		atmosphereScaleHeight = 8.5
+
+		// IF YOU MODIFY pressureCurve then you MUST ensure that maxAtmosphereAltitude is set to the highest altitude present in pressureCurve (in meters)
 		maxAtmosphereAltitude = 130000
+
 		useLegacyAtmosphere = False
 		gravParameter = 3.986004418e+14
 		// These splines approximate the ISA up to the mesopause. From then on the
@@ -399,6 +406,7 @@ REALSOLARSYSTEM
 		// preserve continuity; note that the minimax is thus done on two parametres
 		// rather than four).
 		// now hacked off at 130km where Q ~= 1 for 12km/sec reentry.
+		// IF YOU MODIFY pressureCurve then you MUST ensure that maxAtmosphereAltitude is set to the highest altitude present in pressureCurve (in meters)
 		pressureCurve
 		{
 			// The units are km, atm, atm / km, atm / km.
@@ -557,7 +565,7 @@ REALSOLARSYSTEM
 		}
 		temperatureCurve
 		{
-			// The units are km, °C, K / km, K / km.
+			// The units are km, ï¿½C, K / km, K / km.
 			// The relative error in absolute temperature is at most 2e-15, the
 			// absolute error at sea level is thus about 400 fK.
 			key =   0.                   15.                    -6.5                  -6.500000000001275
@@ -929,7 +937,7 @@ REALSOLARSYSTEM
 		//SSTScale = 0.9832
 		SSTScale = 1.0
 		Radius = 1737100
-		bodyDescription = The Moon is Earth’s only satellite, a large, gray, and rather barren rock. It is the only other body besides Earth that humans have stepped on and, briefly, called home. 
+		bodyDescription = The Moon is Earthï¿½s only satellite, a large, gray, and rather barren rock. It is the only other body besides Earth that humans have stepped on and, briefly, called home. 
 		rotationPeriod = 2360584.68479999
 		initialRotation = 25
 		tidallyLocked = true
@@ -1044,11 +1052,15 @@ REALSOLARSYSTEM
 		tidallyLocked = false
 		axialTilt = 25.19
 		atmosphereScaleHeight = 11.1
-		maxAtmosphereAltitude = 170000
+
+		// IF YOU MODIFY pressureCurve then you MUST ensure that maxAtmosphereAltitude is set to the highest altitude present in pressureCurve (in meters)
+		maxAtmosphereAltitude = 130000
+
 		atmosphereMultiplier = 0.02
 		//GeeASL = 0.379
 		Mass = 6.4185E+23
 		useLegacyAtmosphere = false
+		// IF YOU MODIFY pressureCurve then you MUST ensure that maxAtmosphereAltitude is set to the highest altitude present in pressureCurve (in meters)
 		pressureCurve
 		{
 			key = 	0	0.0129372225	0	-0.0010685874
@@ -1350,7 +1362,7 @@ REALSOLARSYSTEM
 		//bodyName = Deimos
 		SSTScale = 1
 		Radius = 5456
-		bodyDescription = The second natural satellite around Mars, Deimos is named after Phobos’ twin brother, said to personify terror.
+		bodyDescription = The second natural satellite around Mars, Deimos is named after Phobosï¿½ twin brother, said to personify terror.
 		tidallyLocked = true
 		Mass = 1.48E+15
 		atmosphereScaleHeight = 0.175
@@ -1436,7 +1448,7 @@ REALSOLARSYSTEM
 		//SSTScale = 0.9999
 		SSTScale = 1.0
 		Radius = 69911000
-		bodyDescription = The largest planet in our solar system, the gas giant Jupiter. This planet alone is two and a half times the mass of all of the other planets in the Solar System combined. Made up largely of hydrogen and helium with a relatively mysterious rocky core of heavy elements, Jupiter bears a unique and beautiful cosmic painting of various layers with a prominent and awe-inspiring storm that is said to have existed possibly over three-centuries. Jupiter has at least sixty-seven moons counting the four large “Galilean Moons”, one of which has a greater diameter than the first planet Mercury.
+		bodyDescription = The largest planet in our solar system, the gas giant Jupiter. This planet alone is two and a half times the mass of all of the other planets in the Solar System combined. Made up largely of hydrogen and helium with a relatively mysterious rocky core of heavy elements, Jupiter bears a unique and beautiful cosmic painting of various layers with a prominent and awe-inspiring storm that is said to have existed possibly over three-centuries. Jupiter has at least sixty-seven moons counting the four large ï¿½Galilean Moonsï¿½, one of which has a greater diameter than the first planet Mercury.
 		rotationPeriod = 35730
 		tidallyLocked = false
 		axialTilt = 3.13
@@ -1484,7 +1496,7 @@ REALSOLARSYSTEM
 		SSTScale = 1
 		Radius = 1811300 // 1821300 actual, offset 10km down
 		// 5.7km max other PQS + 20km heightmap
-		bodyDescription = The closest Galilean moon to Jupiter, and the fourth-largest moon in our Solar System, Io, like all other Galilean moons, was named after one of Zeus’s lovers. Io is the most active body in the Solar System geologically which produces an effect on the other moons in Jupiter’s grasp. There have been observations of large eruptions that are estimated to rise up to five-hundred-kilometers. Io is made up of silicate rock with an iron sulfide core which can give it the distinctive look achieved by plains coated in sulfur and sulfur dioxide.
+		bodyDescription = The closest Galilean moon to Jupiter, and the fourth-largest moon in our Solar System, Io, like all other Galilean moons, was named after one of Zeusï¿½s lovers. Io is the most active body in the Solar System geologically which produces an effect on the other moons in Jupiterï¿½s grasp. There have been observations of large eruptions that are estimated to rise up to five-hundred-kilometers. Io is made up of silicate rock with an iron sulfide core which can give it the distinctive look achieved by plains coated in sulfur and sulfur dioxide.
 		tidallyLocked = true
 		Mass = 8.9319E+22
 		atmosphereScaleHeight = 5
@@ -1859,11 +1871,15 @@ REALSOLARSYSTEM
 		rotationPeriod = 1377648
 		tidallyLocked = true
 		atmosphereScaleHeight = 30
+
+		// IF YOU MODIFY pressureCurve then you MUST ensure that maxAtmosphereAltitude is set to the highest altitude present in pressureCurve (in meters)
 		maxAtmosphereAltitude = 600000
+
 		atmosphereMultiplier = 1.5
 		//staticPressureASL = 2
 		Mass = 1.3452E+23
 		useLegacyAtmosphere = False
+		// IF YOU MODIFY pressureCurve then you MUST ensure that maxAtmosphereAltitude is set to the highest altitude present in pressureCurve (in meters)
 		pressureCurve
 		{
 			key = 	0	1.470430574	0	-0.073040858
@@ -2151,7 +2167,7 @@ REALSOLARSYSTEM
 		//bodyName = Uranus
 		SSTScale = 1
 		Radius = 25559000
-		bodyDescription = The seventh planet in our neighborhood, Uranus, named after the Greek god of the sky, is similar to the relatively nearby planet Neptune. Uranus is sometimes placed in a category separate from gas giants, known as “Ice Giants”. Having a similar atmosphere to Jupiter and Saturn, Uranus is different from the two gas giants in that it contains more water, ammonia and methane. It also has the coldest planetary atmosphere, somewhere around -224 ºC.
+		bodyDescription = The seventh planet in our neighborhood, Uranus, named after the Greek god of the sky, is similar to the relatively nearby planet Neptune. Uranus is sometimes placed in a category separate from gas giants, known as ï¿½Ice Giantsï¿½. Having a similar atmosphere to Jupiter and Saturn, Uranus is different from the two gas giants in that it contains more water, ammonia and methane. It also has the coldest planetary atmosphere, somewhere around -224 ï¿½C.
 		rotationPeriod = 62063.712
 		tidallyLocked = false
 		axialTilt = 97.77
@@ -2205,7 +2221,7 @@ REALSOLARSYSTEM
 		//bodyName = Pluto
 		SSTScale = 1
 		Radius = 1143000 // 1153km
-		bodyDescription = Recently removed from the planetary list, Pluto has been dubbed a “minor-planet” It is the largest object in the Kuiper belt second most massive known dwarf planet. Pluto is mostly comprised of rock and ice and is quite small. 
+		bodyDescription = Recently removed from the planetary list, Pluto has been dubbed a ï¿½minor-planetï¿½ It is the largest object in the Kuiper belt second most massive known dwarf planet. Pluto is mostly comprised of rock and ice and is quite small. 
 		rotationPeriod = 551856.672
 		tidallyLocked = false
 		axialTilt = 119.591


### PR DESCRIPTION
Fixed bad maxAtmosphereAltitude.
Added warning in front of each pressureCurve field against not keeping maxAtmosphereAltitude up to date.
(simply put: if you change pressureCurve, make sure to update maxAtmosphereAltitude so final altitude matches last pressureCurveKey (has to be in meters))
