### PR TITLE
Updated heightmap load to include AppRoot in Path

### DIFF
--- a/Source/RealSolarSystem.cs
+++ b/Source/RealSolarSystem.cs
@@ -826,7 +826,7 @@ namespace RealSolarSystem
                                             if (File.Exists(KSPUtil.ApplicationRootPath + modNode.GetValue("heightMap")))
                                             {
                                                 Texture2D map = new Texture2D(4, 4, TextureFormat.Alpha8, false);
-                                                map.LoadImage(System.IO.File.ReadAllBytes(modNode.GetValue("heightMap")));
+                                                map.LoadImage(System.IO.File.ReadAllBytes(KSPUtil.ApplicationRootPath + modNode.GetValue("heightMap")));
                                                 yield return null;
                                                 //print("*RSS* MapSO: depth " + mod.heightMap.Depth + "(" + mod.heightMap.Width + "x" + mod.heightMap.Height + ")");
                                                 //System.IO.File.WriteAllBytes("oldHeightmap.png", mod.heightMap.CompileToTexture().EncodeToPNG());


### PR DESCRIPTION
Was having errors and failure running RSS and found that this one map load routine is missing its absolute path. Caused lockups for me.

I think it Fixes #30 
