### PR TITLE
Change to Earth's description

### DIFF
--- a/RealSolarSystem/RealSolarSystem.cfg
+++ b/RealSolarSystem/RealSolarSystem.cfg
@@ -367,7 +367,7 @@ REALSOLARSYSTEM
 		//bodyName = Earth
 		SSTScale = 1
 		Radius = 6371000
-		bodyDescription = The Pale Blue Dot, home to over seven-billion humans and trillions of other life-forms of various shapes and sizes. Earth is where you are in our neighborhood, our home, for now, it is our very only place in the vast expanse of our marvelous universe. 
+		bodyDescription = The Pale Blue Dot, home to over eight-billion humans and trillions of other life-forms of various shapes and sizes. Earth is where you are in our neighborhood, our home, for now, it is our very only place in the vast expanse of our marvelous universe. 
 		// Stellar day.
 		rotationPeriod = 86164.098903691
 		// Inital rotation computed from http://ephemeris.com/ephemeris.php.


### PR DESCRIPTION
Updated the Earth's description to eight-billion humans on earth, instead of seven-billion. As of 2023, the current world population is estimated to be above 8 billion people. (https://www.unfpa.org/press/world-set-reach-8-billion-people-15-november-2022)

Super simple change, also my first pull request and I wanted to check out how github works.